### PR TITLE
Remove temporary files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,16 @@ jobs:
         cp ./x64-windows-mt-v142.cmake C:/ivdv/vcpkg/triplets
         C:/ivdv/vcpkg/vcpkg.exe install --triplet=x64-windows-mt-v142 opencv[dnn] yaml-cpp wxwidgets bfgroup-lyra eigen3 spdlog
 
-        
+    # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
+    # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 
+    # See https://github.com/microsoft/vcpkg/issues/10365  
+    - name: Cleanup vcpkg temporary directories
+      shell: cmd 
+      run: |
+        RMDIR /Q/S C:\ivdv\vcpkg\buildtrees
+        RMDIR /Q/S C:\ivdv\vcpkg\packages
+        RMDIR /Q/S C:\ivdv\vcpkg\downloads
+
     - name: Prepare release file
       if: github.event_name == 'release'
       shell: cmd 


### PR DESCRIPTION
Otherwise the release archive will be too big (like ~17 GB) without any benefit.